### PR TITLE
Added changes a view changes from jesseduffield fork

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -573,6 +573,14 @@ func corner(v *View, directions byte) rune {
 // drawFrameCorners draws the corners of the view.
 func (g *Gui) drawFrameCorners(v *View, fgColor, bgColor Attribute) error {
 	if v.y0 == v.y1 {
+		if !g.SupportOverlaps && v.x0 >= 0 && v.x1 >= 0 && v.y0 >= 0 && v.x0 < g.maxX && v.x1 < g.maxX && v.y0 < g.maxY {
+			if err := g.SetRune(v.x0, v.y0, '╶', fgColor, bgColor); err != nil {
+				return err
+			}
+			if err := g.SetRune(v.x1, v.y0, '╴', fgColor, bgColor); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 
@@ -726,7 +734,7 @@ func (g *Gui) execKeybindings(v *View, ev *termbox.Event) (matched bool, err err
 		if kb.matchView(v) {
 			return g.execKeybinding(v, kb)
 		}
-		if kb.viewName == "" && (!v.Editable || kb.ch == 0) {
+		if kb.viewName == "" && ((v != nil && !v.Editable) || kb.ch == 0) {
 			globalKb = kb
 		}
 	}

--- a/keybinding.go
+++ b/keybinding.go
@@ -35,10 +35,7 @@ func (kb *keybinding) matchKeypress(key Key, ch rune, mod Modifier) bool {
 // matchView returns if the keybinding matches the current view.
 func (kb *keybinding) matchView(v *View) bool {
 	// if the user is typing in a field, ignore char keys
-	if v == nil {
-		return false
-	}
-	if v.Editable && kb.ch != 0 {
+	if v == nil || (v.Editable && kb.ch != 0) {
 		return false
 	}
 	return kb.viewName == v.name

--- a/keybinding.go
+++ b/keybinding.go
@@ -35,6 +35,9 @@ func (kb *keybinding) matchKeypress(key Key, ch rune, mod Modifier) bool {
 // matchView returns if the keybinding matches the current view.
 func (kb *keybinding) matchView(v *View) bool {
 	// if the user is typing in a field, ignore char keys
+	if v == nil {
+		return false
+	}
 	if v.Editable && kb.ch != 0 {
 		return false
 	}


### PR DESCRIPTION
This adds and fixes 2 things:  
- The 1 line height boxes will have a `╴` and `╶` at the start and end: https://github.com/jesseduffield/gocui/pull/5
- The change of getting a panic/error by providing wrong data is reduced: https://github.com/jesseduffield/gocui/pull/6