### PR TITLE
Pad syscall correctly in getTermWindowSize

### DIFF
--- a/gui_others.go
+++ b/gui_others.go
@@ -21,6 +21,7 @@ func (g *Gui) getTermWindowSize() (int, int, error) {
 	var sz struct {
 		rows uint16
 		cols uint16
+		_    [2]uint16 // to match underlying syscall; see https://github.com/awesome-gocui/gocui/issues/33
 	}
 
 	var termw, termh int


### PR DESCRIPTION
Fixes #33

Given that 1.13 comes out soon, it is probably worth cutting a point release after merging this.