### PR TITLE
Fix manual bounds checks in View.SetLine

### DIFF
--- a/view.go
+++ b/view.go
@@ -690,7 +690,7 @@ func indexFunc(r rune) bool {
 
 // SetLine changes the contents of an existing line.
 func (v *View) SetLine(y int, text string) error {
-	if y > len(v.lines) {
+	if y < 0 || y >= len(v.lines) {
 		err := ErrInvalidPoint
 		return err
 	}


### PR DESCRIPTION
The lower bound check was missing;
the higher bound check was off by one.