### PR TITLE
Add option to enable keybindings in editable view

### DIFF
--- a/keybinding.go
+++ b/keybinding.go
@@ -111,7 +111,7 @@ func (kb *keybinding) matchKeypress(key Key, ch rune, mod Modifier) bool {
 // matchView returns if the keybinding matches the current view.
 func (kb *keybinding) matchView(v *View) bool {
 	// if the user is typing in a field, ignore char keys
-	if v == nil || (v.Editable && kb.ch != 0) {
+	if v == nil || (v.Editable && kb.ch != 0 && !v.KeybindOnEdit) {
 		return false
 	}
 	return kb.viewName == v.name

--- a/view.go
+++ b/view.go
@@ -111,6 +111,10 @@ type View struct {
 
 	// If HasLoader is true, the message will be appended with a spinning loader animation
 	HasLoader bool
+
+	// KeybindOnEdit should be set to true when you want to execute keybindings even when the view is editable
+	// (this is usually not the case)
+	KeybindOnEdit bool
 }
 
 type viewLine struct {


### PR DESCRIPTION
Defaults to false to not change old behaviour.

To enable this, simply set `v.KeybindOnEdit = true` on any editable view and you should be good to go.