### PR TITLE
Support maximum number of lines for a view

### DIFF
--- a/view.go
+++ b/view.go
@@ -528,7 +528,7 @@ func (v *View) draw() error {
 	}
 
 	if v.Autoscroll && len(v.viewLines) > maxY {
-		v.oy = len(v.viewLines) - maxY
+		v.oy = len(v.viewLines) - maxY - 1
 	}
 	y := 0
 	for i, vline := range v.viewLines {

--- a/view.go
+++ b/view.go
@@ -115,6 +115,9 @@ type View struct {
 	// KeybindOnEdit should be set to true when you want to execute keybindings even when the view is editable
 	// (this is usually not the case)
 	KeybindOnEdit bool
+
+	// Set the maximum number of lines to store
+	MaxLines int
 }
 
 type viewLine struct {
@@ -363,6 +366,13 @@ func (v *View) WriteString(s string) {
 // writeRunes copies slice of runes into internal lines buffer.
 // caller must make sure that writing position is accessable.
 func (v *View) writeRunes(p []rune) {
+
+	// Cap the maximum number of lines in the view
+	if v.MaxLines > 0 && len(v.lines) > v.MaxLines {
+		cut := len(v.lines) - v.MaxLines
+		v.lines = v.lines[cut:]
+	}
+
 	for _, r := range p {
 		switch r {
 		case '\n':

--- a/view.go
+++ b/view.go
@@ -387,7 +387,7 @@ func (v *View) writeRunes(p []rune) {
 			v.wx = 0
 		default:
 			cells := v.parseInput(r)
-			if cells == nil {
+			if cells == nil || len(cells) <= 0 {
 				continue
 			}
 			v.writeCells(v.wx, v.wy, cells)


### PR DESCRIPTION
Added a variable to a View to support capping the number of lines in a lines, defaults to be infinite.