### PR TITLE
Add frame customization

### DIFF
--- a/_examples/custom_frame.go
+++ b/_examples/custom_frame.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/awesome-gocui/gocui"
+)
+
+var (
+	viewArr = []string{"v1", "v2", "v3", "v4"}
+	active  = 0
+)
+
+func setCurrentViewOnTop(g *gocui.Gui, name string) (*gocui.View, error) {
+	if _, err := g.SetCurrentView(name); err != nil {
+		return nil, err
+	}
+	return g.SetViewOnTop(name)
+}
+
+func nextView(g *gocui.Gui, v *gocui.View) error {
+	nextIndex := (active + 1) % len(viewArr)
+	name := viewArr[nextIndex]
+
+	out, err := g.View("v1")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(out, "Going from view "+v.Name()+" to "+name)
+
+	if _, err := setCurrentViewOnTop(g, name); err != nil {
+		return err
+	}
+
+	if nextIndex == 3 {
+		g.Cursor = true
+	} else {
+		g.Cursor = false
+	}
+
+	active = nextIndex
+	return nil
+}
+
+func layout(g *gocui.Gui) error {
+	maxX, maxY := g.Size()
+	if v, err := g.SetView("v1", 0, 0, maxX/2-1, maxY/2-1, gocui.RIGHT); err != nil {
+		if !gocui.IsUnknownView(err) {
+			return err
+		}
+		v.Title = "v1"
+		v.Autoscroll = true
+		fmt.Fprintln(v, "View with default frame color")
+		fmt.Fprintln(v, "It's connected to v2 with overlay RIGHT.\n")
+		if _, err = setCurrentViewOnTop(g, "v1"); err != nil {
+			return err
+		}
+	}
+
+	if v, err := g.SetView("v2", maxX/2-1, 0, maxX-1, maxY/2-1, gocui.LEFT); err != nil {
+		if !gocui.IsUnknownView(err) {
+			return err
+		}
+		v.Title = "v2"
+		v.Wrap = true
+		v.FrameColor = gocui.ColorMagenta
+		v.FrameRunes = []rune{'═', '│'}
+		fmt.Fprintln(v, "View with minimum frame customization and colored frame.")
+		fmt.Fprintln(v, "It's connected to v1 with overlay LEFT.\n")
+		fmt.Fprintln(v, "\033[35;1mInstructions:\033[0m")
+		fmt.Fprintln(v, "Press TAB to change current view")
+		fmt.Fprintln(v, "Press Ctrl+O to toggle gocui.SupportOverlap\n")
+		fmt.Fprintln(v, "\033[32;2mSelected frame is highlighted with green color\033[0m")
+	}
+	if v, err := g.SetView("v3", 0, maxY/2, maxX/2-1, maxY-1, 0); err != nil {
+		if !gocui.IsUnknownView(err) {
+			return err
+		}
+		v.Title = "v3"
+		v.Wrap = true
+		v.Autoscroll = true
+		v.FrameColor = gocui.ColorCyan
+		v.TitleColor = gocui.ColorCyan
+		v.FrameRunes = []rune{'═', '║', '╔', '╗', '╚', '╝'}
+		fmt.Fprintln(v, "View with basic frame customization and colored frame and title")
+		fmt.Fprintln(v, "It's not connected to any view.")
+	}
+	if v, err := g.SetView("v4", maxX/2, maxY/2, maxX-1, maxY-1, gocui.LEFT); err != nil {
+		if !gocui.IsUnknownView(err) {
+			return err
+		}
+		v.Title = "v4"
+		v.Subtitle = "(editable)"
+		v.Editable = true
+		v.TitleColor = gocui.ColorYellow
+		v.FrameColor = gocui.ColorRed
+		v.FrameRunes = []rune{'═', '║', '╔', '╗', '╚', '╝', '╠', '╣', '╦', '╩', '╬'}
+		fmt.Fprintln(v, "View with fully customized frame and colored title differently.")
+		fmt.Fprintln(v, "It's connected to v3 with overlay LEFT.\n")
+		v.SetCursor(0, 3)
+	}
+	return nil
+}
+
+func quit(g *gocui.Gui, v *gocui.View) error {
+	return gocui.ErrQuit
+}
+
+func toggleOverlap(g *gocui.Gui, v *gocui.View) error {
+	g.SupportOverlaps = !g.SupportOverlaps
+	return nil
+}
+
+func main() {
+	g, err := gocui.NewGui(gocui.OutputNormal, true)
+	if err != nil {
+		log.Panicln(err)
+	}
+	defer g.Close()
+
+	g.Highlight = true
+	g.SelFgColor = gocui.ColorGreen
+	g.SelFrameColor = gocui.ColorGreen
+
+	g.SetManagerFunc(layout)
+
+	if err := g.SetKeybinding("", gocui.KeyCtrlC, gocui.ModNone, quit); err != nil {
+		log.Panicln(err)
+	}
+	if err := g.SetKeybinding("", gocui.KeyCtrlO, gocui.ModNone, toggleOverlap); err != nil {
+		log.Panicln(err)
+	}
+	if err := g.SetKeybinding("", gocui.KeyTab, gocui.ModNone, nextView); err != nil {
+		log.Panicln(err)
+	}
+
+	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+		log.Panicln(err)
+	}
+}

--- a/view.go
+++ b/view.go
@@ -87,6 +87,24 @@ type View struct {
 	// If Frame is true, a border will be drawn around the view.
 	Frame bool
 
+	// FrameColor allow to configure the color of the Frame when it is not highlighted.
+	FrameColor Attribute
+
+	// FrameRunes allows to define custom runes for the frame edges.
+	// The rune slice can be defined with 3 different lengths.
+	// If slice doesn't match these lengths, default runes will be used instead of missing one.
+	//
+	// 2 runes with only horizontal and vertical edges.
+	//  []rune{'─', '│'}
+	//  []rune{'═','║'}
+	// 6 runes with horizontal, vertical edges and top-left, top-right, bottom-left, bottom-right cornes.
+	//  []rune{'─', '│', '┌', '┐', '└', '┘'}
+	//  []rune{'═','║','╔','╗','╚','╝'}
+	// 11 runes which can be used with `gocui.Gui.SupportOverlaps` property.
+	//  []rune{'─', '│', '┌', '┐', '└', '┘', '├', '┤', '┬', '┴', '┼'}
+	//  []rune{'═','║','╔','╗','╚','╝','╠','╣','╦','╩','╬'}
+	FrameRunes []rune
+
 	// If Wrap is true, the content that is written to this View is
 	// automatically wrapped when it is longer than its width. If true the
 	// view's x-origin will be ignored.
@@ -98,6 +116,9 @@ type View struct {
 
 	// If Frame is true, Title allows to configure a title for the view.
 	Title string
+
+	// TitleColor allow to configure the color of title and subtitle for the view.
+	TitleColor Attribute
 
 	// If Frame is true, Subtitle allows to configure a subtitle for the view.
 	Subtitle string


### PR DESCRIPTION
This PR adds `View.Frame` customization.

`View.FrameColor` can be specified to change default color of the frame. 
`View.TitleColor` can be specified to change default color for `View.Title` and `View.Subtitle`
These colors are used only if `Gui.Highlight=false` or if the customized view is not current.

To maintain backward compatibility, if any of these color is not set (or set to `ColorDefault` which is `0`) original colors are used.

`View.FrameRunes` slice can be specified for View allowing to change frame style.
The slice length determine how many customized runes will be used and the rest would be filled from the defaults (kinda, this applies from length > 6).
I added there `cornerCustomRune()` function which is used to translate indexes for `cornerRune()` into indexes for `View.FrameRunes`.

There is also `_examples/custom_frame.go` example, which is customized form of `_examples/active.go` example.
It has 4 different views with 4 different setups to demonstrate the customization available and also to show the `Gui.SupportOverlay` option functionality.

Fixes #71 .