### PR TITLE
use Go 1.13 errors instead of go-errors/errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 }
@@ -91,7 +91,7 @@ func main() {
 func layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 	if v, err := g.SetView("hello", maxX/2-7, maxY/2, maxX/2+7, maxY/2+2, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 

--- a/_examples/active.go
+++ b/_examples/active.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 
@@ -50,7 +51,7 @@ func nextView(g *gocui.Gui, v *gocui.View) error {
 func layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 	if v, err := g.SetView("v1", 0, 0, maxX/2-1, maxY/2-1, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "v1 (editable)"
@@ -63,7 +64,7 @@ func layout(g *gocui.Gui) error {
 	}
 
 	if v, err := g.SetView("v2", maxX/2-1, 0, maxX-1, maxY/2-1, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "v2"
@@ -71,7 +72,7 @@ func layout(g *gocui.Gui) error {
 		v.Autoscroll = true
 	}
 	if v, err := g.SetView("v3", 0, maxY/2-1, maxX/2-1, maxY-1, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "v3"
@@ -80,7 +81,7 @@ func layout(g *gocui.Gui) error {
 		fmt.Fprint(v, "Press TAB to change current view")
 	}
 	if v, err := g.SetView("v4", maxX/2, maxY/2, maxX-1, maxY-1, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "v4 (editable)"
@@ -113,7 +114,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 }

--- a/_examples/bufs.go
+++ b/_examples/bufs.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 
@@ -29,7 +30,7 @@ func overwrite(g *gocui.Gui, v *gocui.View) error {
 func layout(g *gocui.Gui) error {
 	_, maxY := g.Size()
 	if v, err := g.SetView("main", 0, 0, 20, maxY-1, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Editable = true
@@ -59,7 +60,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 

--- a/_examples/colors.go
+++ b/_examples/colors.go
@@ -24,7 +24,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 }
@@ -32,7 +32,7 @@ func main() {
 func layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 	if v, err := g.SetView("colors", maxX/2-7, maxY/2-12, maxX/2+7, maxY/2+13, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		for i := 0; i <= 7; i++ {

--- a/_examples/colors256.go
+++ b/_examples/colors256.go
@@ -25,7 +25,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 }
@@ -33,7 +33,7 @@ func main() {
 func layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 	if v, err := g.SetView("colors", -1, -1, maxX, maxY, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 

--- a/_examples/colorstrue.go
+++ b/_examples/colorstrue.go
@@ -43,7 +43,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 }
@@ -60,7 +60,7 @@ func layout(g *gocui.Gui) error {
 	}
 
 	if v, err := g.SetView("colors", 0, 0, cols-1, rows-1, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 

--- a/_examples/custom_frame.go
+++ b/_examples/custom_frame.go
@@ -46,7 +46,7 @@ func nextView(g *gocui.Gui, v *gocui.View) error {
 func layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 	if v, err := g.SetView("v1", 0, 0, maxX/2-1, maxY/2-1, gocui.RIGHT); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "v1"
@@ -59,7 +59,7 @@ func layout(g *gocui.Gui) error {
 	}
 
 	if v, err := g.SetView("v2", maxX/2-1, 0, maxX-1, maxY/2-1, gocui.LEFT); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "v2"
@@ -74,7 +74,7 @@ func layout(g *gocui.Gui) error {
 		fmt.Fprintln(v, "\033[32;2mSelected frame is highlighted with green color\033[0m")
 	}
 	if v, err := g.SetView("v3", 0, maxY/2, maxX/2-1, maxY-1, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "v3"
@@ -87,7 +87,7 @@ func layout(g *gocui.Gui) error {
 		fmt.Fprintln(v, "It's not connected to any view.")
 	}
 	if v, err := g.SetView("v4", maxX/2, maxY/2, maxX-1, maxY-1, gocui.LEFT); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "v4"
@@ -135,7 +135,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 }

--- a/_examples/demo.go
+++ b/_examples/demo.go
@@ -60,7 +60,7 @@ func getLine(g *gocui.Gui, v *gocui.View) error {
 
 	maxX, maxY := g.Size()
 	if v, err := g.SetView("msg", maxX/2-30, maxY/2, maxX/2+30, maxY/2+2, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		fmt.Fprintln(v, l)
@@ -160,7 +160,7 @@ func saveVisualMain(g *gocui.Gui, v *gocui.View) error {
 func layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 	if v, err := g.SetView("side", -1, -1, 30, maxY, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Highlight = true
@@ -173,7 +173,7 @@ func layout(g *gocui.Gui) error {
 		fmt.Fprint(v, "deleted\rItem 4\nItem 5")
 	}
 	if v, err := g.SetView("main", 30, -1, maxX, maxY, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		b, err := ioutil.ReadFile("Mark.Twain-Tom.Sawyer.txt")
@@ -205,7 +205,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 }

--- a/_examples/dynamic.go
+++ b/_examples/dynamic.go
@@ -40,7 +40,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 }
@@ -49,7 +49,7 @@ func layout(g *gocui.Gui) error {
 	maxX, _ := g.Size()
 	v, err := g.SetView("help", maxX-25, 0, maxX-1, 9, 0)
 	if err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		fmt.Fprintln(v, "KEYBINDINGS")
@@ -135,7 +135,7 @@ func newView(g *gocui.Gui) error {
 	name := fmt.Sprintf("v%v", idxView)
 	v, err := g.SetView(name, maxX/2-5, maxY/2-5, maxX/2+5, maxY/2+5, 0)
 	if err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Wrap = true

--- a/_examples/flow_layout.go
+++ b/_examples/flow_layout.go
@@ -36,7 +36,7 @@ func NewLabel(name string, body string) *Label {
 func (w *Label) Layout(g *gocui.Gui) error {
 	v, err := g.SetView(w.name, 0, 0, w.w, w.h, 0)
 	if err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		fmt.Fprint(v, w.body)
@@ -53,7 +53,7 @@ func flowLayout(g *gocui.Gui) error {
 	for _, v := range views {
 		w, h := v.Size()
 		_, err := g.SetView(v.Name(), x, 0, x+w+1, h+1, 0)
-		if err != nil && !gocui.IsUnknownView(err) {
+		if err != nil && !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		x += w + 2
@@ -80,7 +80,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 }

--- a/_examples/goroutine.go
+++ b/_examples/goroutine.go
@@ -41,7 +41,7 @@ func main() {
 		go counter(g)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 
@@ -50,7 +50,7 @@ func main() {
 
 func layout(g *gocui.Gui) error {
 	if v, err := g.SetView("ctr", 2, 2, 22, 2+NumGoroutines+1, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Clear()

--- a/_examples/hello.go
+++ b/_examples/hello.go
@@ -24,7 +24,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 }
@@ -32,7 +32,7 @@ func main() {
 func layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 	if v, err := g.SetView("hello", maxX/2-7, maxY/2, maxX/2+7, maxY/2+2, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 

--- a/_examples/keybinds.go
+++ b/_examples/keybinds.go
@@ -10,7 +10,7 @@ import (
 func layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 	if v, err := g.SetView("hello", maxX/2-7, maxY/2, maxX/2+7, maxY/2+2, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 

--- a/_examples/layout.go
+++ b/_examples/layout.go
@@ -12,17 +12,17 @@ import (
 
 func layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
-	if _, err := g.SetView("side", -1, -1, int(0.2*float32(maxX)), maxY-5, 0); err != nil && !gocui.IsUnknownView(err) {
+	if _, err := g.SetView("side", -1, -1, int(0.2*float32(maxX)), maxY-5, 0); err != nil && !errors.Is(err, gocui.ErrUnknownView) {
 		return err
 	}
 	if _, err := g.SetView("main", int(0.2*float32(maxX)), -1, maxX, maxY-5, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 
 		g.SetCurrentView("main")
 	}
-	if _, err := g.SetView("cmdline", -1, maxY-5, maxX, maxY, 0); err != nil && !gocui.IsUnknownView(err) {
+	if _, err := g.SetView("cmdline", -1, maxY-5, maxX, maxY, 0); err != nil && !errors.Is(err, gocui.ErrUnknownView) {
 		return err
 	}
 
@@ -46,7 +46,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 }

--- a/_examples/mask.go
+++ b/_examples/mask.go
@@ -26,7 +26,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Fatalln(err)
 	}
 }
@@ -35,7 +35,7 @@ func layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 
 	if v, err := g.SetView("help", maxX-23, 0, maxX-1, 3, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "Keybindings"
@@ -44,7 +44,7 @@ func layout(g *gocui.Gui) error {
 	}
 
 	if v, err := g.SetView("input", 0, 0, maxX-24, maxY-1, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		if _, err := g.SetCurrentView("input"); err != nil {

--- a/_examples/mouse.go
+++ b/_examples/mouse.go
@@ -27,14 +27,14 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 }
 
 func layout(g *gocui.Gui) error {
 	if v, err := g.SetView("but1", 2, 2, 22, 7, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Highlight = true
@@ -49,7 +49,7 @@ func layout(g *gocui.Gui) error {
 		}
 	}
 	if v, err := g.SetView("but2", 24, 2, 44, 4, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Highlight = true
@@ -100,7 +100,7 @@ func showMsg(g *gocui.Gui, v *gocui.View) error {
 
 	maxX, maxY := g.Size()
 	if v, err := g.SetView("msg", maxX/2-10, maxY/2, maxX/2+10, maxY/2+2, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		fmt.Fprintln(v, l)

--- a/_examples/ontop.go
+++ b/_examples/ontop.go
@@ -24,26 +24,26 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 }
 
 func layout(g *gocui.Gui) error {
 	if v, err := g.SetView("v1", 10, 2, 30, 6, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		fmt.Fprintln(v, "View #1")
 	}
 	if v, err := g.SetView("v2", 20, 4, 40, 8, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		fmt.Fprintln(v, "View #2")
 	}
 	if v, err := g.SetView("v3", 30, 6, 50, 10, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		fmt.Fprintln(v, "View #3")

--- a/_examples/overlap.go
+++ b/_examples/overlap.go
@@ -13,39 +13,39 @@ import (
 func layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 	if _, err := g.SetView("v1", -1, -1, 10, 10, 0); err != nil &&
-		!gocui.IsUnknownView(err) {
+		!errors.Is(err, gocui.ErrUnknownView) {
 		return err
 	}
 	if _, err := g.SetView("v2", maxX-10, -1, maxX, 10, 0); err != nil &&
-		!gocui.IsUnknownView(err) {
+		!errors.Is(err, gocui.ErrUnknownView) {
 		return err
 	}
 	if _, err := g.SetView("v3", maxX/2-5, -1, maxX/2+5, 10, 0); err != nil &&
-		!gocui.IsUnknownView(err) {
+		!errors.Is(err, gocui.ErrUnknownView) {
 		return err
 	}
 	if _, err := g.SetView("v4", -1, maxY/2-5, 10, maxY/2+5, 0); err != nil &&
-		!gocui.IsUnknownView(err) {
+		!errors.Is(err, gocui.ErrUnknownView) {
 		return err
 	}
 	if _, err := g.SetView("v5", maxX-10, maxY/2-5, maxX, maxY/2+5, 0); err != nil &&
-		!gocui.IsUnknownView(err) {
+		!errors.Is(err, gocui.ErrUnknownView) {
 		return err
 	}
 	if _, err := g.SetView("v6", -1, maxY-10, 10, maxY, 0); err != nil &&
-		!gocui.IsUnknownView(err) {
+		!errors.Is(err, gocui.ErrUnknownView) {
 		return err
 	}
 	if _, err := g.SetView("v7", maxX-10, maxY-10, maxX, maxY, 0); err != nil &&
-		!gocui.IsUnknownView(err) {
+		!errors.Is(err, gocui.ErrUnknownView) {
 		return err
 	}
 	if _, err := g.SetView("v8", maxX/2-5, maxY-10, maxX/2+5, maxY, 0); err != nil &&
-		!gocui.IsUnknownView(err) {
+		!errors.Is(err, gocui.ErrUnknownView) {
 		return err
 	}
 	if _, err := g.SetView("v9", maxX/2-5, maxY/2-5, maxX/2+5, maxY/2+5, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		if _, err := g.SetCurrentView("v9"); err != nil {
@@ -72,7 +72,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 }

--- a/_examples/size.go
+++ b/_examples/size.go
@@ -24,7 +24,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 }
@@ -33,7 +33,7 @@ func layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 	v, err := g.SetView("size", maxX/2-7, maxY/2, maxX/2+7, maxY/2+2, 0)
 	if err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		if _, err := g.SetCurrentView("size"); err != nil {

--- a/_examples/stdin.go
+++ b/_examples/stdin.go
@@ -31,7 +31,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Fatalln(err)
 	}
 }
@@ -40,7 +40,7 @@ func layout(g *gocui.Gui) error {
 	maxX, _ := g.Size()
 
 	if v, err := g.SetView("help", maxX-23, 0, maxX-1, 5, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		fmt.Fprintln(v, "KEYBINDINGS")
@@ -50,7 +50,7 @@ func layout(g *gocui.Gui) error {
 	}
 
 	if v, err := g.SetView("stdin", 0, 0, 80, 35, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Wrap = true

--- a/_examples/table.go
+++ b/_examples/table.go
@@ -35,7 +35,7 @@ func NewTable(name string, left, top, right, bottom int) *Table {
 
 func (t *Table) Layout(g *gocui.Gui) error {
 	view, err := g.SetView(t.name, t.Left, t.Top, t.Right, t.Bottom, 0)
-	if err != nil && !gocui.IsUnknownView(err) {
+	if err != nil && !errors.Is(err, gocui.ErrUnknownView) {
 		return err
 	}
 

--- a/_examples/title.go
+++ b/_examples/title.go
@@ -23,7 +23,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 }
@@ -37,13 +37,13 @@ func layout(g *gocui.Gui) error {
 
 	// Overlap (front)
 	if v, err := g.SetView("v1", 10, 2, 30, 6, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "Regular title"
 	}
 	if v, err := g.SetView("v2", 20, 4, 40, 8, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "Regular title"
@@ -51,13 +51,13 @@ func layout(g *gocui.Gui) error {
 
 	// Overlap (back)
 	if v, err := g.SetView("v3", 60, 4, 80, 8, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "Regular title"
 	}
 	if v, err := g.SetView("v4", 50, 2, 70, 6, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "Regular title"
@@ -65,25 +65,25 @@ func layout(g *gocui.Gui) error {
 
 	// Overlap (frame)
 	if v, err := g.SetView("v15", 90, 2, 110, 5, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "Regular title"
 	}
 	if v, err := g.SetView("v16", 100, 5, 120, 8, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "Regular title"
 	}
 	if v, err := g.SetView("v17", 140, 5, 160, 8, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "Regular title"
 	}
 	if v, err := g.SetView("v18", 130, 2, 150, 5, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "Regular title"
@@ -91,7 +91,7 @@ func layout(g *gocui.Gui) error {
 
 	// Long title
 	if v, err := g.SetView("v5", 10, 12, 30, 16, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "Long long long long title"
@@ -99,20 +99,20 @@ func layout(g *gocui.Gui) error {
 
 	// No title
 	if v, err := g.SetView("v6", 35, 12, 55, 16, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = ""
 	}
 	if _, err := g.SetView("v7", 60, 12, 80, 16, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 	}
 
 	// Small view
 	if v, err := g.SetView("v8", 85, 12, 88, 16, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "Regular title"
@@ -120,13 +120,13 @@ func layout(g *gocui.Gui) error {
 
 	// Screen borders
 	if v, err := g.SetView("v9", -10, 20, 10, 24, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "Regular title"
 	}
 	if v, err := g.SetView("v10", maxX-10, 20, maxX+10, 24, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "Regular title"
@@ -134,25 +134,25 @@ func layout(g *gocui.Gui) error {
 
 	// Out of screen
 	if v, err := g.SetView("v11", -21, 28, -1, 32, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "Regular title"
 	}
 	if v, err := g.SetView("v12", maxX, 28, maxX+20, 32, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "Regular title"
 	}
 	if v, err := g.SetView("v13", 10, -7, 30, -1, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "Regular title"
 	}
 	if v, err := g.SetView("v14", 10, maxY, 30, maxY+6, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Title = "Regular title"

--- a/_examples/widgets.go
+++ b/_examples/widgets.go
@@ -41,7 +41,7 @@ func NewHelpWidget(name string, x, y int, body string) *HelpWidget {
 func (w *HelpWidget) Layout(g *gocui.Gui) error {
 	v, err := g.SetView(w.name, w.x, w.y, w.x+w.w, w.y+w.h, 0)
 	if err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		fmt.Fprint(v, w.body)
@@ -74,7 +74,7 @@ func (w *StatusbarWidget) Val() float64 {
 
 func (w *StatusbarWidget) Layout(g *gocui.Gui) error {
 	v, err := g.SetView(w.name, w.x, w.y, w.x+w.w, w.y+2, 0)
-	if err != nil && !gocui.IsUnknownView(err) {
+	if err != nil && !errors.Is(err, gocui.ErrUnknownView) {
 		return err
 	}
 	v.Clear()
@@ -99,7 +99,7 @@ func NewButtonWidget(name string, x, y int, label string, handler func(g *gocui.
 func (w *ButtonWidget) Layout(g *gocui.Gui) error {
 	v, err := g.SetView(w.name, w.x, w.y, w.x+w.w, w.y+2, 0)
 	if err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		if _, err := g.SetCurrentView(w.name); err != nil {
@@ -136,7 +136,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 }

--- a/_examples/wrap.go
+++ b/_examples/wrap.go
@@ -15,7 +15,7 @@ import (
 func layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 	if v, err := g.SetView("main", 1, 1, maxX-1, maxY-1, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 		v.Wrap = true
@@ -48,7 +48,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 }

--- a/doc.go
+++ b/doc.go
@@ -16,7 +16,7 @@ Create a new GUI:
 	// Set GUI managers and key bindings
 	// ...
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		// handle error
 	}
 
@@ -38,7 +38,7 @@ their content. The same is valid for reading.
 Create and initialize a view with absolute coordinates:
 
 	if v, err := g.SetView("viewname", 2, 2, 22, 7, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			// handle error
 		}
 		fmt.Fprintln(v, "This is a new view")

--- a/edit.go
+++ b/edit.go
@@ -5,7 +5,7 @@
 package gocui
 
 import (
-	"github.com/go-errors/errors"
+	"errors"
 
 	"github.com/mattn/go-runewidth"
 )

--- a/escape.go
+++ b/escape.go
@@ -5,9 +5,8 @@
 package gocui
 
 import (
+	"errors"
 	"strconv"
-
-	"github.com/go-errors/errors"
 )
 
 type escapeInterpreter struct {

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/awesome-gocui/gocui
 
-go 1.12
+go 1.13
 
 require (
 	github.com/gdamore/tcell/v2 v2.0.0
-	github.com/go-errors/errors v1.0.2
+	github.com/lucasb-eyer/go-colorful v1.0.3
 	github.com/mattn/go-runewidth v0.0.9
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdk
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/tcell/v2 v2.0.0 h1:GRWG8aLfWAlekj9Q6W29bVvkHENc6hp79XOqG4AWDOs=
 github.com/gdamore/tcell/v2 v2.0.0/go.mod h1:vSVL/GV5mCSlPC6thFP5kfOFdM9MGZcalipmpTxTgQA=
-github.com/go-errors/errors v1.0.2 h1:xMxH9j2fNg/L4hLn/4y3M0IUsn0M6Wbu/Uh9QlOfBh4=
-github.com/go-errors/errors v1.0.2/go.mod h1:psDX2osz5VnTOnFWbDeWwS7yejl+uV3FEWEp4lssFEs=
 github.com/lucasb-eyer/go-colorful v1.0.3 h1:QIbQXiugsb+q10B+MI+7DI1oQLdmnep86tWFlaaUAac=
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=

--- a/gui.go
+++ b/gui.go
@@ -5,10 +5,8 @@
 package gocui
 
 import (
-	standardErrors "errors"
+	"errors"
 	"runtime"
-
-	"github.com/go-errors/errors"
 )
 
 // OutputMode represents an output mode, which determines how colors
@@ -17,22 +15,22 @@ type OutputMode int
 
 var (
 	// ErrAlreadyBlacklisted is returned when the keybinding is already blacklisted.
-	ErrAlreadyBlacklisted = standardErrors.New("keybind already blacklisted")
+	ErrAlreadyBlacklisted = errors.New("keybind already blacklisted")
 
 	// ErrBlacklisted is returned when the keybinding being parsed / used is blacklisted.
-	ErrBlacklisted = standardErrors.New("keybind blacklisted")
+	ErrBlacklisted = errors.New("keybind blacklisted")
 
 	// ErrNotBlacklisted is returned when a keybinding being whitelisted is not blacklisted.
-	ErrNotBlacklisted = standardErrors.New("keybind not blacklisted")
+	ErrNotBlacklisted = errors.New("keybind not blacklisted")
 
 	// ErrNoSuchKeybind is returned when the keybinding being parsed does not exist.
-	ErrNoSuchKeybind = standardErrors.New("no such keybind")
+	ErrNoSuchKeybind = errors.New("no such keybind")
 
 	// ErrUnknownView allows to assert if a View must be initialized.
-	ErrUnknownView = standardErrors.New("unknown view")
+	ErrUnknownView = errors.New("unknown view")
 
 	// ErrQuit is used to decide if the MainLoop finished successfully.
-	ErrQuit = standardErrors.New("quit")
+	ErrQuit = errors.New("quit")
 )
 
 const (
@@ -198,7 +196,7 @@ func (g *Gui) SetView(name string, x0, y0, x1, y1 int, overlaps byte) (*View, er
 	v.SelBgColor, v.SelFgColor = g.SelBgColor, g.SelFgColor
 	v.Overlaps = overlaps
 	g.views = append(g.views, v)
-	return v, errors.Wrap(ErrUnknownView, 0)
+	return v, ErrUnknownView
 }
 
 // SetViewBeneath sets a view stacked beneath another view
@@ -221,7 +219,7 @@ func (g *Gui) SetViewOnTop(name string) (*View, error) {
 			return v, nil
 		}
 	}
-	return nil, errors.Wrap(ErrUnknownView, 0)
+	return nil, ErrUnknownView
 }
 
 // SetViewOnBottom sets the given view on bottom of the existing ones.
@@ -233,7 +231,7 @@ func (g *Gui) SetViewOnBottom(name string) (*View, error) {
 			return v, nil
 		}
 	}
-	return nil, errors.Wrap(ErrUnknownView, 0)
+	return nil, ErrUnknownView
 }
 
 // Views returns all the views in the GUI.
@@ -249,7 +247,7 @@ func (g *Gui) View(name string) (*View, error) {
 			return v, nil
 		}
 	}
-	return nil, errors.Wrap(ErrUnknownView, 0)
+	return nil, ErrUnknownView
 }
 
 // ViewByPosition returns a pointer to a view matching the given position, or
@@ -262,7 +260,7 @@ func (g *Gui) ViewByPosition(x, y int) (*View, error) {
 			return v, nil
 		}
 	}
-	return nil, errors.Wrap(ErrUnknownView, 0)
+	return nil, ErrUnknownView
 }
 
 // ViewPosition returns the coordinates of the view with the given name, or
@@ -273,7 +271,7 @@ func (g *Gui) ViewPosition(name string) (x0, y0, x1, y1 int, err error) {
 			return v.x0, v.y0, v.x1, v.y1, nil
 		}
 	}
-	return 0, 0, 0, 0, errors.Wrap(ErrUnknownView, 0)
+	return 0, 0, 0, 0, ErrUnknownView
 }
 
 // DeleteView deletes a view by name.
@@ -284,7 +282,7 @@ func (g *Gui) DeleteView(name string) error {
 			return nil
 		}
 	}
-	return errors.Wrap(ErrUnknownView, 0)
+	return ErrUnknownView
 }
 
 // SetCurrentView gives the focus to a given view.
@@ -295,7 +293,7 @@ func (g *Gui) SetCurrentView(name string) (*View, error) {
 			return v, nil
 		}
 	}
-	return nil, errors.Wrap(ErrUnknownView, 0)
+	return nil, ErrUnknownView
 }
 
 // CurrentView returns the currently focused view, or nil if no view
@@ -917,14 +915,4 @@ func (g *Gui) isBlacklisted(k Key) bool {
 		}
 	}
 	return false
-}
-
-// IsUnknownView reports whether the contents of an error is "unknown view".
-func IsUnknownView(err error) bool {
-	return err != nil && err.Error() == ErrUnknownView.Error()
-}
-
-// IsQuit reports whether the contents of an error is "quit".
-func IsQuit(err error) bool {
-	return err != nil && err.Error() == ErrQuit.Error()
 }

--- a/gui_others.go
+++ b/gui_others.go
@@ -7,12 +7,11 @@
 package gocui
 
 import (
+	"errors"
 	"os"
 	"os/signal"
 	"syscall"
 	"unsafe"
-
-	"github.com/go-errors/errors"
 )
 
 // getTermWindowSize is get terminal window size on linux or unix.

--- a/migrate-to-v1.md
+++ b/migrate-to-v1.md
@@ -82,3 +82,7 @@ The original translation from `termbox` was included in GOCUI to be backward com
 In general, all the keys in GOCUI should be presented from before, but the underlying values might be different. This could lead to some problems if a user uses different parser to create the `Key` for the keybinding. If using GOCUI parser, everything should be ok.
 
 Mouse is handled differently in `tcell`, but translation was done to keep it in the same way as it was before. However this was harder to test due to different behaviour across the platforms, so if anything is missing or not working, please report.
+
+### Error checking
+
+`IsQuit` and `IsUnknownView` helper functions has been removed in favour of standard checking functions `errors.Is` and `errors.As`.

--- a/view.go
+++ b/view.go
@@ -6,12 +6,12 @@ package gocui
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"strings"
 	"sync"
 	"unicode/utf8"
 
-	"github.com/go-errors/errors"
 	"github.com/mattn/go-runewidth"
 )
 


### PR DESCRIPTION
This PR addresses issue https://github.com/awesome-gocui/gocui/issues/58.

It removes all usages of `github.com/go-errors/errors` as well as helper functions `IsQuit` and `IsUnknownView` in favour of standard Go errors introspection methods presented in Go 1.13.