### PR TITLE
Feature/update doc and examples

### DIFF
--- a/_examples/colors.go
+++ b/_examples/colors.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 

--- a/_examples/colors256.go
+++ b/_examples/colors256.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 

--- a/_examples/colorstrue.go
+++ b/_examples/colorstrue.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"

--- a/_examples/custom_frame.go
+++ b/_examples/custom_frame.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 

--- a/_examples/demo.go
+++ b/_examples/demo.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"

--- a/_examples/dynamic.go
+++ b/_examples/dynamic.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"

--- a/_examples/flow_layout.go
+++ b/_examples/flow_layout.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"

--- a/_examples/goroutine.go
+++ b/_examples/goroutine.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"sync"

--- a/_examples/hello.go
+++ b/_examples/hello.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 

--- a/_examples/keybinds.go
+++ b/_examples/keybinds.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 
 	"github.com/awesome-gocui/gocui"

--- a/_examples/layout.go
+++ b/_examples/layout.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 
 	"github.com/awesome-gocui/gocui"

--- a/_examples/mask.go
+++ b/_examples/mask.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 

--- a/_examples/mouse.go
+++ b/_examples/mouse.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 

--- a/_examples/ontop.go
+++ b/_examples/ontop.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 

--- a/_examples/overlap.go
+++ b/_examples/overlap.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 
 	"github.com/awesome-gocui/gocui"

--- a/_examples/size.go
+++ b/_examples/size.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 

--- a/_examples/stdin.go
+++ b/_examples/stdin.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"log"

--- a/_examples/table.go
+++ b/_examples/table.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 
 	"github.com/awesome-gocui/gocui"

--- a/_examples/title.go
+++ b/_examples/title.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 
 	"github.com/awesome-gocui/gocui"

--- a/_examples/widgets.go
+++ b/_examples/widgets.go
@@ -5,11 +5,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"
-
-	"github.com/go-errors/errors"
 
 	"github.com/awesome-gocui/gocui"
 )

--- a/_examples/wrap.go
+++ b/_examples/wrap.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"

--- a/migrate-to-v1.md
+++ b/migrate-to-v1.md
@@ -83,6 +83,17 @@ In general, all the keys in GOCUI should be presented from before, but the under
 
 Mouse is handled differently in `tcell`, but translation was done to keep it in the same way as it was before. However this was harder to test due to different behaviour across the platforms, so if anything is missing or not working, please report.
 
+## Changes in gocui functions
 ### Error checking
 
-`IsQuit` and `IsUnknownView` helper functions has been removed in favour of standard checking functions `errors.Is` and `errors.As`.
+`IsQuit` and `IsUnknownView` helper functions has been removed in favour of standard checking functions `errors.Is` and `errors.As`.    
+To ease the migration, you can do search&replace like this (it might not work for all cases):
+- `IsUnknownView` - search for regex `gocui\.IsUnknownView\((.*)\)`, reaplce `errors.Is($1, gocui.ErrUnknownView)`
+- `IsQuit` - search for regex `gocui\.IsQuit\((.*)\)`, replace `errors.Is($1, gocui.ErrQuit)`
+- updated files need to be updated with `goimports` to import `errors` package
+
+### View.MoveCursor 
+
+`gocui.View.MoveCursor()` function parameters were changed. `writeMode` parameter has been removed. It has now only 2 parameters `dx` and `dy`.     
+To remove the additional parameter from your code (if used), you can do search&replace like this (it might not work for all cases):
+- search for regex `\.MoveCursor\((.*), [^\),]+\)`, replace `.MoveCursor($1)`


### PR DESCRIPTION
This PR updates the migration documentation with some suggestion how to easily update the functions which were changed from `v0` to `v1`.

It also fixes all the examples to be runnable (they did not have correct imports). 