### PR TITLE
Create public methods to init and close tcell screen

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -101,7 +101,7 @@ type Gui struct {
 
 // NewGui returns a new Gui object with a given output mode.
 func NewGui(mode OutputMode, supportOverlaps bool) (*Gui, error) {
-	err := TcellInit()
+	err := tcellInit()
 	if err != nil {
 		return nil, err
 	}

--- a/gui.go
+++ b/gui.go
@@ -101,7 +101,7 @@ type Gui struct {
 
 // NewGui returns a new Gui object with a given output mode.
 func NewGui(mode OutputMode, supportOverlaps bool) (*Gui, error) {
-	err := tcellInit()
+	err := TcellInit()
 	if err != nil {
 		return nil, err
 	}

--- a/tcell_driver.go
+++ b/tcell_driver.go
@@ -10,8 +10,8 @@ import (
 
 var screen tcell.Screen
 
-// tcellInit initializes tcell screen for use.
-func tcellInit() error {
+// TcellInit initializes tcell screen for use.
+func TcellInit() error {
 	if s, e := tcell.NewScreen(); e != nil {
 		return e
 	} else if e = s.Init(); e != nil {
@@ -20,6 +20,11 @@ func tcellInit() error {
 		screen = s
 		return nil
 	}
+}
+
+// TcellClose closes the tcell screen allowing other terminal apps to run.
+func TcellClose() {
+	screen.Fini()
 }
 
 // tcellSetCell sets the character cell at a given location to the given

--- a/tcell_driver.go
+++ b/tcell_driver.go
@@ -10,8 +10,8 @@ import (
 
 var screen tcell.Screen
 
-// TcellInit initializes tcell screen for use.
-func TcellInit() error {
+// tcellInit initializes tcell screen for use.
+func tcellInit() error {
 	if s, e := tcell.NewScreen(); e != nil {
 		return e
 	} else if e = s.Init(); e != nil {
@@ -22,9 +22,14 @@ func TcellInit() error {
 	}
 }
 
-// TcellClose closes the tcell screen allowing other terminal apps to run.
-func TcellClose() {
+// Suspend closes the tcell screen allowing other terminal apps to run
+func Suspend() {
 	screen.Fini()
+}
+
+// Resume re-initializes the tcell screen, intended to be used after "Suspend" has been called
+func Resume() error {
+	return tcellInit()
 }
 
 // tcellSetCell sets the character cell at a given location to the given


### PR DESCRIPTION
As mentioned in #83 this change enables azbrowse to load another terminal app then, once it has closed, re-enable the gocui.

Our calls to this look like this:

```
        if editorConfig.RevertToStandardBuffer {
		// Close to revert to normal buffer
		gocui.TCellClose()
	}

        // open nano/vim or other and wait for it to close
	editorErr := openEditor(editorConfig.Command, editorTmpFile)


	if editorConfig.RevertToStandardBuffer {
		// Init tcell to switch back to alternate buffer and Flush content
		gocui.TcellInit()
	}
```