### PR TITLE
_examples: fix lack of error stdlib importing

### DIFF
--- a/_examples/colors.go
+++ b/_examples/colors.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 

--- a/_examples/colors256.go
+++ b/_examples/colors256.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 

--- a/_examples/colorstrue.go
+++ b/_examples/colorstrue.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"

--- a/_examples/custom_frame.go
+++ b/_examples/custom_frame.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 

--- a/_examples/demo.go
+++ b/_examples/demo.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"

--- a/_examples/dynamic.go
+++ b/_examples/dynamic.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"

--- a/_examples/flow_layout.go
+++ b/_examples/flow_layout.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"

--- a/_examples/goroutine.go
+++ b/_examples/goroutine.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"sync"

--- a/_examples/hello.go
+++ b/_examples/hello.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 

--- a/_examples/keybinds.go
+++ b/_examples/keybinds.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 
 	"github.com/awesome-gocui/gocui"

--- a/_examples/layout.go
+++ b/_examples/layout.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 
 	"github.com/awesome-gocui/gocui"

--- a/_examples/mask.go
+++ b/_examples/mask.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 

--- a/_examples/mouse.go
+++ b/_examples/mouse.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 

--- a/_examples/ontop.go
+++ b/_examples/ontop.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 

--- a/_examples/overlap.go
+++ b/_examples/overlap.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 
 	"github.com/awesome-gocui/gocui"

--- a/_examples/size.go
+++ b/_examples/size.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 

--- a/_examples/stdin.go
+++ b/_examples/stdin.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"log"

--- a/_examples/table.go
+++ b/_examples/table.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 
 	"github.com/awesome-gocui/gocui"

--- a/_examples/title.go
+++ b/_examples/title.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 
 	"github.com/awesome-gocui/gocui"

--- a/_examples/wrap.go
+++ b/_examples/wrap.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"


### PR DESCRIPTION
_examples: Fix lack of error stdlib importing.

Currently, `_examples/*.go` can't compiling.
Fixed #75 (https://github.com/awesome-gocui/gocui/commit/6f7659f26d2b2fcec9d867b19630ffb3b81b0fbe)  change.