### PR TITLE
Less strict rules for SetCursor

### DIFF
--- a/edit.go
+++ b/edit.go
@@ -154,7 +154,6 @@ func (v *View) EditNewLine() {
 	v.ox = 0
 	v.cy = v.cy + 1
 	v.cx = 0
-	v.moveCursor(0, 1)
 }
 
 // MoveCursor mores the cursor relative from it's current possition

--- a/view.go
+++ b/view.go
@@ -229,7 +229,7 @@ func (v *View) setRune(x, y int, ch rune, fgColor, bgColor Attribute) error {
 	return nil
 }
 
-// SetCursorUnsafe sets the cursor position of the view at the given point
+// SetCursorUnrestricted sets the cursor position of the view at the given point
 // This does NOT check if the x and y location are available in the buffer
 //
 // Rules:

--- a/view.go
+++ b/view.go
@@ -229,18 +229,29 @@ func (v *View) setRune(x, y int, ch rune, fgColor, bgColor Attribute) error {
 	return nil
 }
 
-// SetCursor sets the cursor position of the view at the given point,
+// SetCursorUnsafe sets the cursor position of the view at the given point
+// This does NOT check if the x and y location are available in the buffer
 //
 // Rules:
 //   y >= 0
 //   x >= 0
-//
-// If the x or y are outside of the buffer this function will place the cursor on the nearest buffer location
-func (v *View) SetCursor(x, y int) error {
+func (v *View) SetCursorUnrestricted(x, y int) error {
 	if x < 0 || y < 0 {
 		return ErrInvalidPoint
 	}
 
+	v.cx = x
+	v.cy = y
+	return nil
+}
+
+// SetCursor tries sets the cursor position of the view at the given point
+// If the x or y are outside of the buffer this function will place the cursor on the nearest buffer location
+//
+// Rules:
+//   y >= 0
+//   x >= 0
+func (v *View) SetCursor(x, y int) error {
 	if y >= len(v.lines) && y != 0 {
 		y = len(v.lines) - 1
 	}
@@ -253,9 +264,7 @@ func (v *View) SetCursor(x, y int) error {
 		}
 	}
 
-	v.cx = x
-	v.cy = y
-	return nil
+	return v.SetCursorUnrestricted(x, y)
 }
 
 // Cursor returns the cursor position of the view.

--- a/view.go
+++ b/view.go
@@ -232,11 +232,25 @@ func (v *View) setRune(x, y int, ch rune, fgColor, bgColor Attribute) error {
 // SetCursor sets the cursor position of the view at the given point,
 //
 // Rules:
-//   y < total lines && y > 0
-//   (x < view width || x < y's line width) && x > 0
+//   y >= 0
+//   x >= 0
+//
+// If the x or y are outside of the buffer this function will place the cursor on the nearest buffer location
 func (v *View) SetCursor(x, y int) error {
-	if x < 0 || y < 0 || (y >= len(v.lines) && y != 0) || (x > 0 && (len(v.lines) == 0 || len(v.lines[y]) < x)) {
+	if x < 0 || y < 0 {
 		return ErrInvalidPoint
+	}
+
+	if y >= len(v.lines) && y != 0 {
+		y = len(v.lines) - 1
+	}
+
+	if x > 0 && (len(v.lines) == 0 || len(v.lines[y]) < x) {
+		if len(v.lines) == 0 {
+			x = 0
+		} else {
+			x = len(v.lines[y])
+		}
 	}
 
 	v.cx = x


### PR DESCRIPTION
Fixes #81

This makes it so the SetCursor defaults to nearest buffer location if the x and y are not available in the buffer.  
Also added `SetCursorUnrestricted` a function that doesn't check if the location is a valid buffer location.  