### PR TITLE
Ensure view.SetCursor doesn't set an invalid point when the view is empty

### DIFF
--- a/view.go
+++ b/view.go
@@ -252,7 +252,9 @@ func (v *View) SetCursorUnrestricted(x, y int) error {
 //   y >= 0
 //   x >= 0
 func (v *View) SetCursor(x, y int) error {
-	if y >= len(v.lines) && y != 0 {
+	if len(v.lines) == 0 {
+		y = 0
+	} else if y >= len(v.lines) && y != 0 {
 		y = len(v.lines) - 1
 	}
 


### PR DESCRIPTION
Currently, if `view.SetCursor` is called on an empty view with a `y > 0`, the `x` and `y` values that are passed to `view.SetCursorUnrestricted` are `0` and `-1` respectively which is an invalid point.

This change ensures that if the view is empty, the `y` value passed to `view.SetCursorUnrestricted` will be set to `0`.