### PR TITLE
Fix bugs in _examples/

### DIFF
--- a/_examples/dynamic.go
+++ b/_examples/dynamic.go
@@ -78,6 +78,12 @@ func initKeybindings(g *gocui.Gui) error {
 		}); err != nil {
 		return err
 	}
+	if err := g.SetKeybinding("", gocui.KeyBackspace, gocui.ModNone,
+		func(g *gocui.Gui, v *gocui.View) error {
+			return delView(g)
+		}); err != nil {
+		return err
+	}
 	if err := g.SetKeybinding("", gocui.KeyBackspace2, gocui.ModNone,
 		func(g *gocui.Gui, v *gocui.View) error {
 			return delView(g)

--- a/_examples/mouse.go
+++ b/_examples/mouse.go
@@ -19,7 +19,7 @@ func main() {
 	}
 	defer g.Close()
 
-	g.Cursor = true
+	g.Cursor = false
 	g.Mouse = true
 
 	g.SetManagerFunc(layout)

--- a/_examples/table.go
+++ b/_examples/table.go
@@ -43,7 +43,7 @@ func (t *Table) Layout(g *gocui.Gui) error {
 	width, height := view.Size()
 	hOffset := 0
 	for cid, column := range t.Columns {
-		size := int(float32(width) * column.Size)
+		size := int(float32(width+1) * column.Size)
 
 		view.SetWritePos(hOffset, 0)
 		view.WriteString(column.Title)
@@ -53,7 +53,7 @@ func (t *Table) Layout(g *gocui.Gui) error {
 				view.SetWritePos(hOffset, rid+1)
 				view.WriteString(t.Data[cid][rid])
 			}
-			view.SetWritePos(hOffset+size-3, rid)
+			view.SetWritePos(hOffset+size-1, rid)
 			view.WriteRunes([]rune{'│'})
 		}
 
@@ -70,7 +70,7 @@ func main() {
 	}
 	defer g.Close()
 
-	table := NewTable("t", 1, 2, 80, 10)
+	table := NewTable("t", 0, 2, 80, 10)
 	table.Columns = []Column{
 		{"Column1", 0.25},
 		{"Column2", 0.25},


### PR DESCRIPTION
- Add `KeyBackspace`  keybind to `dynamic.go` to match input prompt (`"Backspace: Delete View"`)
- Fix table alignment in `table.go`
  - Spacing issue caused by not accounting for empty `char`s being rendered as `' '` in `View.draw`: 
![spacing issue](https://user-images.githubusercontent.com/53288101/143131333-1c2fc7c6-cf14-4078-a9a9-b04b93fac6b4.png)
  - Minor issue in example when trying to align columns properly: 
![alignment issue](https://user-images.githubusercontent.com/53288101/143131442-32c19ae2-0781-4426-aa86-555185ec16b0.png)
  - (fixed): 
![fixed table](https://user-images.githubusercontent.com/53288101/143131563-f39203cd-7019-43dd-89ba-4b091e3efff4.png)
- Disable visible cursor in `mouse.go` due to it being entirely mouse-controlled

