### PR TITLE
Implemented mouse release handling

### DIFF
--- a/_examples/mouse.go
+++ b/_examples/mouse.go
@@ -44,7 +44,6 @@ func layout(g *gocui.Gui) error {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
-		v.Highlight = true
 		v.SelBgColor = gocui.ColorGreen
 		v.SelFgColor = gocui.ColorBlack
 		fmt.Fprintln(v, "Button 1 - line 1")
@@ -59,11 +58,11 @@ func layout(g *gocui.Gui) error {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
-		v.Highlight = true
 		v.SelBgColor = gocui.ColorGreen
 		v.SelFgColor = gocui.ColorBlack
 		fmt.Fprintln(v, "Button 2 - line 1")
 	}
+	updateHighlightedView(g)
 	return nil
 }
 
@@ -105,9 +104,21 @@ func showMsg(g *gocui.Gui, v *gocui.View) error {
 	maxX, maxY := g.Size()
 	if v, err := g.SetView("msg", maxX/2-10, maxY/2, maxX/2+10, maxY/2+2, 0); err == nil || errors.Is(err, gocui.ErrUnknownView) {
 		v.Clear()
+		v.SelBgColor = gocui.ColorCyan
+		v.SelFgColor = gocui.ColorBlack
 		fmt.Fprintln(v, l)
 	}
 	return nil
+}
+
+func updateHighlightedView(g *gocui.Gui) {
+	mx, my := g.MousePosition()
+	for _, view := range g.Views() {
+		view.Highlight = false
+	}
+	if v, err := g.ViewByPosition(mx, my); err == nil {
+		v.Highlight = true
+	}
 }
 
 func moveMsg(g *gocui.Gui) {

--- a/gui.go
+++ b/gui.go
@@ -144,6 +144,7 @@ func NewGui(mode OutputMode, supportOverlaps bool) (*Gui, error) {
 		g.maxX, g.maxY = screen.Size()
 	}
 
+	g.mouseX, g.mouseY = -1, -1
 	g.BgColor, g.FgColor, g.FrameColor = ColorDefault, ColorDefault, ColorDefault
 	g.SelBgColor, g.SelFgColor, g.SelFrameColor = ColorDefault, ColorDefault, ColorDefault
 

--- a/gui.go
+++ b/gui.go
@@ -169,6 +169,8 @@ func (g *Gui) Size() (x, y int) {
 	return g.maxX, g.maxY
 }
 
+// MousePosition returns the last position of the mouse.
+// If no mouse event was triggered yet MousePosition will return -1, -1.
 func (g *Gui) MousePosition() (x, y int) {
 	return g.mouseX, g.mouseY
 }

--- a/gui.go
+++ b/gui.go
@@ -76,6 +76,9 @@ type Gui struct {
 	testCounter int // used for testing synchronization
 	testNotify  chan struct{}
 
+	// The position of the mouse
+	mouseX, mouseY int
+
 	// BgColor and FgColor allow to configure the background and foreground
 	// colors of the GUI.
 	BgColor, FgColor, FrameColor Attribute
@@ -163,6 +166,10 @@ func (g *Gui) Close() {
 // Size returns the terminal's size.
 func (g *Gui) Size() (x, y int) {
 	return g.maxX, g.maxY
+}
+
+func (g *Gui) MousePosition() (x, y int) {
+	return g.mouseX, g.mouseY
 }
 
 // SetRune writes a rune at the given point, relative to the top-left
@@ -881,6 +888,8 @@ func (g *Gui) onKey(ev *gocuiEvent) error {
 		}
 	case eventMouse:
 		mx, my := ev.MouseX, ev.MouseY
+		g.mouseX = mx
+		g.mouseY = my
 		v, err := g.ViewByPosition(mx, my)
 		if err != nil {
 			break

--- a/tcell_driver.go
+++ b/tcell_driver.go
@@ -174,7 +174,7 @@ func pollEvent() gocuiEvent {
 	case *tcell.EventMouse:
 		x, y := tev.Position()
 		button := tev.Buttons()
-		mouseKey := MouseRelease
+		mouseKey := Key(0)
 		mouseMod := ModNone
 		// process mouse wheel
 		if button&tcell.WheelUp != 0 {
@@ -199,19 +199,21 @@ func pollEvent() gocuiEvent {
 		if button != tcell.ButtonNone && lastMouseKey == tcell.ButtonNone {
 			lastMouseKey = button
 			lastMouseMod = tev.Modifiers()
+			switch tev.Buttons() {
+			case tcell.ButtonPrimary:
+				mouseKey = MouseLeft
+			case tcell.ButtonSecondary:
+				mouseKey = MouseRight
+			case tcell.ButtonMiddle:
+				mouseKey = MouseMiddle
+			}
+			mouseMod = Modifier(lastMouseMod)
 		}
 
 		switch tev.Buttons() {
 		case tcell.ButtonNone:
 			if lastMouseKey != tcell.ButtonNone {
-				switch lastMouseKey {
-				case tcell.ButtonPrimary:
-					mouseKey = MouseLeft
-				case tcell.ButtonSecondary:
-					mouseKey = MouseRight
-				case tcell.ButtonMiddle:
-					mouseKey = MouseMiddle
-				}
+				mouseKey = MouseRelease
 				mouseMod = Modifier(lastMouseMod)
 				lastMouseMod = tcell.ModNone
 				lastMouseKey = tcell.ButtonNone


### PR DESCRIPTION
This PR adds/fixes a few things:

- Send mouse button events on mouse down just like the termbox version did
- Send mouse release event only after all buttons have been released (Closes #99)
- Track mouse position and expose it to the user to allow for creating drag interactions
- Add all these features to the example:
   - Clicking on one of the buttons shows the message after down event
   - Message can be dragged around
   - Message is deleted if the user does not move the move and releases the button again
   - Only highlight hovered view (Closes #108)
   - Dragging based on the border using the mouseposition
   - Showing mouse down and up anywhere outside the buttons