### PR TITLE
Allow more mouse modifiers and include them on mousewheel events

### DIFF
--- a/keybinding.go
+++ b/keybinding.go
@@ -288,7 +288,6 @@ const (
 const (
 	ModNone       Modifier = Modifier(0)
 	ModAlt                 = Modifier(tcell.ModAlt)
-	ModMouseAlt            = Modifier(tcell.ModAlt)
 	ModMouseShift          = Modifier(tcell.ModShift)
 	ModMouseCtrl           = Modifier(tcell.ModCtrl)
 )

--- a/keybinding.go
+++ b/keybinding.go
@@ -286,8 +286,9 @@ const (
 
 // Modifiers.
 const (
-	ModNone Modifier = Modifier(0)
-	ModAlt           = Modifier(tcell.ModAlt)
-	// ModCtrl doesn't work with keyboard keys. Use CtrlKey in Key and ModNone. This is was for mouse clicks only (tcell.v1)
-	// ModCtrl = Modifier(tcell.ModCtrl)
+	ModNone       Modifier = Modifier(0)
+	ModAlt                 = Modifier(tcell.ModAlt)
+	ModMouseAlt            = Modifier(tcell.ModAlt)
+	ModMouseShift          = Modifier(tcell.ModShift)
+	ModMouseCtrl           = Modifier(tcell.ModCtrl)
 )

--- a/tcell_driver.go
+++ b/tcell_driver.go
@@ -179,15 +179,19 @@ func pollEvent() gocuiEvent {
 		// process mouse wheel
 		if button&tcell.WheelUp != 0 {
 			mouseKey = MouseWheelUp
+			mouseMod = Modifier(tev.Modifiers())
 		}
 		if button&tcell.WheelDown != 0 {
 			mouseKey = MouseWheelDown
+			mouseMod = Modifier(tev.Modifiers())
 		}
 		if button&tcell.WheelLeft != 0 {
 			mouseKey = MouseWheelLeft
+			mouseMod = Modifier(tev.Modifiers())
 		}
 		if button&tcell.WheelRight != 0 {
 			mouseKey = MouseWheelRight
+			mouseMod = Modifier(tev.Modifiers())
 		}
 
 		// process button events (not wheel events)


### PR DESCRIPTION
This PR adds support for using all major modifiers for mouse events like scroll and click.
I added the modifiers with `Mouse` in the name so users won't try to use them for keyboard keys