### PR TITLE
Add support for Shift modifier on keys like arrow keys

### DIFF
--- a/keybinding.go
+++ b/keybinding.go
@@ -286,8 +286,12 @@ const (
 
 // Modifiers.
 const (
-	ModNone       Modifier = Modifier(0)
-	ModAlt                 = Modifier(tcell.ModAlt)
-	ModMouseShift          = Modifier(tcell.ModShift)
-	ModMouseCtrl           = Modifier(tcell.ModCtrl)
+	ModNone Modifier = Modifier(0)
+	ModAlt           = Modifier(tcell.ModAlt)
+
+	// ModShift only makes sense on keys that are not characters like the
+	// arrow keys and any mouse keys
+	// Character keys will instead be triggerd as their translated variant.
+	ModShift     = Modifier(tcell.ModShift)
+	ModMouseCtrl = Modifier(tcell.ModCtrl)
 )

--- a/tcell_driver.go
+++ b/tcell_driver.go
@@ -159,7 +159,7 @@ func pollEvent() gocuiEvent {
 			mod = 0
 			ch = rune(0)
 			k = tcell.KeyCtrlSpace
-		} else if mod == tcell.ModCtrl || mod == tcell.ModShift {
+		} else if mod == tcell.ModCtrl || mod == tcell.ModShift && ch != 0 {
 			// remove Ctrl or Shift if specified
 			// - shift - will be translated to the final code of rune
 			// - ctrl  - is translated in the key

--- a/tcell_driver.go
+++ b/tcell_driver.go
@@ -149,17 +149,17 @@ func pollEvent() gocuiEvent {
 			ch = tev.Rune()
 			if ch == ' ' {
 				// special handling for spacebar
-				k = 32 // tcell keys ends at 31 or starts at 256
+				k = tcell.Key(KeySpace) // tcell keys ends at 31 or starts at 256
 				ch = rune(0)
 			}
 		}
 		mod := tev.Modifiers()
 		// remove control modifier and setup special handling of ctrl+spacebar, etc.
-		if mod == tcell.ModCtrl && k == 32 {
+		if mod == tcell.ModCtrl && k == tcell.Key(KeySpace) {
 			mod = 0
 			ch = rune(0)
 			k = tcell.KeyCtrlSpace
-		} else if mod == tcell.ModCtrl || mod == tcell.ModShift && ch != 0 {
+		} else if mod == tcell.ModCtrl || mod == tcell.ModShift && (ch != 0 || k == tcell.Key(KeySpace)) {
 			// remove Ctrl or Shift if specified
 			// - shift - will be translated to the final code of rune
 			// - ctrl  - is translated in the key


### PR DESCRIPTION
It turns out that the shift modifier can be used on the arrow keys so it should not only apply to the mouse