### PR TITLE
Fix highlight and mouse ignoring origin when interacting with cursor

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -897,7 +897,7 @@ func (g *Gui) onKey(ev *gocuiEvent) error {
 		if err != nil {
 			break
 		}
-		if err := v.SetCursor(mx-v.x0-1, my-v.y0-1); err != nil {
+		if err := v.SetCursor(mx-v.x0-1+v.ox, my-v.y0-1+v.oy); err != nil {
 			return err
 		}
 		if _, err := g.execKeybindings(v, ev); err != nil {

--- a/view.go
+++ b/view.go
@@ -214,7 +214,7 @@ func (v *View) setRune(x, y int, ch rune, fgColor, bgColor Attribute) error {
 		fgColor = v.FgColor
 		bgColor = v.BgColor
 		ch = v.Mask
-	} else if v.Highlight && y == v.cy {
+	} else if v.Highlight && y == v.cy - v.oy {
 		fgColor = v.SelFgColor | AttrBold
 		bgColor = v.SelBgColor | AttrBold
 	}

--- a/view.go
+++ b/view.go
@@ -214,7 +214,7 @@ func (v *View) setRune(x, y int, ch rune, fgColor, bgColor Attribute) error {
 		fgColor = v.FgColor
 		bgColor = v.BgColor
 		ch = v.Mask
-	} else if v.Highlight && y == v.cy - v.oy {
+	} else if v.Highlight && y == v.cy-v.oy {
 		fgColor = v.SelFgColor | AttrBold
 		bgColor = v.SelBgColor | AttrBold
 	}


### PR DESCRIPTION
This fixes #118 by doing two things:

1. gui.go: When changing cursor position after receiving mouse events, add x- and y-Origin to the cursor position to place the cursor right under the mouse
2. view.go: When deciding which line to highlight, take y-Origin into account to ensure the line under the cursor is the one that's highlighted.