### PR TITLE
Add support for ANSI color codes in titles & subtitles

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -794,10 +794,18 @@ func (g *Gui) drawFrameCorners(v *View, fgColor, bgColor Attribute) error {
 }
 
 // drawTitle draws the title of the view.
+//
+// If fgColor and/or bgColor ARE ColorDefault and the title contains ANSI color codes, then the
+// text is colored according to those embedded ANSI colors.
+//
+// If fgColor and/or bgColor are NOT ColorDefault, then the title string will use those colors
+// and thus OVERRIDE ANSI color codes embedded within the title string.
 func (g *Gui) drawTitle(v *View, fgColor, bgColor Attribute) error {
 	if v.y0 < 0 || v.y0 >= g.maxY {
 		return nil
 	}
+
+	var cells []cell
 
 	for i, ch := range v.Title {
 		x := v.x0 + i + 2
@@ -806,14 +814,41 @@ func (g *Gui) drawTitle(v *View, fgColor, bgColor Attribute) error {
 		} else if x > v.x1-2 || x >= g.maxX {
 			break
 		}
-		if err := g.SetRune(x, v.y0, ch, fgColor, bgColor); err != nil {
-			return err
+		c := v.parseInput(ch)
+		if c == nil {
+			continue
+		}
+		cells = append(cells, c...)
+	}
+
+	for i, c := range cells {
+		x := v.x0 + i + 2
+
+		if fgColor == ColorDefault && bgColor == ColorDefault {
+			if err := g.SetRune(x, v.y0, c.chr, c.fgColor, c.bgColor); err != nil {
+				return err
+			}
+		} else if fgColor == ColorDefault && bgColor != ColorDefault {
+			if err := g.SetRune(x, v.y0, c.chr, c.fgColor, bgColor); err != nil {
+				return err
+			}
+		} else {
+			if err := g.SetRune(x, v.y0, c.chr, fgColor, c.bgColor); err != nil {
+				return err
+			}
 		}
 	}
+
 	return nil
 }
 
 // drawSubtitle draws the subtitle of the view.
+//
+// If fgColor and/or bgColor ARE ColorDefault and the subtitle contains ANSI color codes, then the
+// text is colored according to those embedded ANSI colors.
+//
+// If fgColor and/or bgColor are NOT ColorDefault, then the subtitle string will use those colors
+// and thus override ANSI color codes embedded within the subtitle string.
 func (g *Gui) drawSubtitle(v *View, fgColor, bgColor Attribute) error {
 	if v.y0 < 0 || v.y0 >= g.maxY {
 		return nil
@@ -823,15 +858,42 @@ func (g *Gui) drawSubtitle(v *View, fgColor, bgColor Attribute) error {
 	if start < v.x0 {
 		return nil
 	}
+
+	var cells []cell
+
 	for i, ch := range v.Subtitle {
 		x := start + i
 		if x >= v.x1 {
 			break
 		}
-		if err := g.SetRune(x, v.y0, ch, fgColor, bgColor); err != nil {
-			return err
+		c := v.parseInput(ch)
+		if c == nil {
+			continue
+		}
+		cells = append(cells, c...)
+	}
+
+	for i, c := range cells {
+		x := start + i
+		if x >= v.x1 {
+			break
+		}
+
+		if fgColor == ColorDefault && bgColor == ColorDefault {
+			if err := g.SetRune(x, v.y0, c.chr, c.fgColor, c.bgColor); err != nil {
+				return err
+			}
+		} else if fgColor == ColorDefault && bgColor != ColorDefault {
+			if err := g.SetRune(x, v.y0, c.chr, c.fgColor, bgColor); err != nil {
+				return err
+			}
+		} else {
+			if err := g.SetRune(x, v.y0, c.chr, fgColor, c.bgColor); err != nil {
+				return err
+			}
 		}
 	}
+
 	return nil
 }
 

--- a/gui.go
+++ b/gui.go
@@ -873,6 +873,9 @@ func (g *Gui) drawSubtitle(v *View, fgColor, bgColor Attribute) error {
 		cells = append(cells, c...)
 	}
 
+	// Update the start location for the subtitle after parsing any ANSI color codes
+	start = v.x1 - 5 - len(cells)
+
 	for i, c := range cells {
 		x := start + i
 		if x >= v.x1 {

--- a/gui.go
+++ b/gui.go
@@ -805,8 +805,8 @@ func (g *Gui) drawTitle(v *View, fgColor, bgColor Attribute) error {
 		return nil
 	}
 
+	// Rebuild the title as []cell by parsing the foreground/background ANSI color codes
 	var cells []cell
-
 	for i, ch := range v.Title {
 		x := v.x0 + i + 2
 		if x < 0 {
@@ -859,8 +859,8 @@ func (g *Gui) drawSubtitle(v *View, fgColor, bgColor Attribute) error {
 		return nil
 	}
 
+	// Rebuild the subtitle as []cell by parsing the foreground/background ANSI color codes
 	var cells []cell
-
 	for i, ch := range v.Subtitle {
 		x := start + i
 		if x >= v.x1 {

--- a/view.go
+++ b/view.go
@@ -117,7 +117,7 @@ type View struct {
 	// If Frame is true, Title allows to configure a title for the view.
 	Title string
 
-	// TitleColor allow to configure the color of title and subtitle for the view.
+	// TitleColor overrides the color of title and subtitle for the view with a single color.
 	TitleColor Attribute
 
 	// If Frame is true, Subtitle allows to configure a subtitle for the view.


### PR DESCRIPTION
Setting view.TitleColor overrides ANSI color codes contained in the titles. If TitleColor is not set (ColorDefault) and the title/subtitle contains ANSI colors - render them!

Here's an example using the following code:

```go
package main

import (
	"errors"
	"github.com/awesome-gocui/gocui"
	"github.com/gdamore/tcell/v2"
	"log"
)

const (
	ESC   string = "\033"
	RESET string = ESC + "[0m"
	RED   string = ESC + "[31m"
	GREEN string = ESC + "[0;32m"
	BLUE  string = ESC + "[0;34m"
)

func layout(g *gocui.Gui) error {
	maxX, maxY := g.Size()

	// View1 => Using ANSI colors but with Title Color set
	view1, err := g.SetView("view1", 0, 0, maxX/3, maxY-1, 0)
	if err != nil && !errors.Is(err, gocui.ErrUnknownView) {
		return err
	}
	view1.Title = "View1: " + RED + "Test Title"
	view1.Subtitle = "Subtitle test"

	// Setting TitleColor overrides any ANSI colors within Title or Subtitle
	view1.TitleColor = gocui.Attribute(tcell.ColorAzure)

	// View2 => Using ANSI colors without setting TitleColor
	view2, err := g.SetView("view2", maxX/3+1, 0, maxX-1, maxY-1, 0)
	if err != nil && !errors.Is(err, gocui.ErrUnknownView) {
		return err
	}
	view2.Title = "View2: " + BLUE + "Title is blue " + RESET + "(" + GREEN + "this is green" + RESET + ")"
	view2.Subtitle = BLUE + "Subtitle is blue" + RESET

	return nil
}

func quit(g *gocui.Gui, v *gocui.View) error {
	return gocui.ErrQuit
}

func main() {
	app, err := gocui.NewGui(gocui.OutputTrue, true)
	if err != nil {
		log.Panicln(err)
	}
	defer app.Close()

	app.SetManagerFunc(layout)

	if err = app.SetKeybinding("", gocui.KeyCtrlC, gocui.ModNone, quit); err != nil {
		log.Panicln(err)
	}

	if err = app.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
		log.Panicln(err)
	}
}
```

Result:

![image](https://github.com/user-attachments/assets/4d41c344-013e-4c3d-bc1e-88c2dd38457a)

