### PR TITLE
docs: Add missing "errors" lib import in example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ See the [\_example](./_example/) folder for more examples
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 


### PR DESCRIPTION
Reduce confustion for the example code in README.md