### PR TITLE
Add padding fields to view

### DIFF
--- a/_examples/custom_frame.go
+++ b/_examples/custom_frame.go
@@ -52,6 +52,7 @@ func layout(g *gocui.Gui) error {
 		}
 		v.Title = "v1"
 		v.Autoscroll = true
+		v.PaddingX = 1
 		fmt.Fprintln(v, "View with default frame color")
 		fmt.Fprintln(v, "It's connected to v2 with overlay RIGHT.\n")
 		if _, err = setCurrentViewOnTop(g, "v1"); err != nil {
@@ -67,6 +68,7 @@ func layout(g *gocui.Gui) error {
 		v.Wrap = true
 		v.FrameColor = gocui.ColorMagenta
 		v.FrameRunes = []rune{'═', '│'}
+		v.PaddingX = 1
 		fmt.Fprintln(v, "View with minimum frame customization and colored frame.")
 		fmt.Fprintln(v, "It's connected to v1 with overlay LEFT.\n")
 		fmt.Fprintln(v, "\033[35;1mInstructions:\033[0m")
@@ -84,6 +86,7 @@ func layout(g *gocui.Gui) error {
 		v.FrameColor = gocui.ColorCyan
 		v.TitleColor = gocui.ColorCyan
 		v.FrameRunes = []rune{'═', '║', '╔', '╗', '╚', '╝'}
+		v.PaddingX = 1
 		fmt.Fprintln(v, "View with basic frame customization and colored frame and title")
 		fmt.Fprintln(v, "It's not connected to any view.")
 	}
@@ -97,6 +100,7 @@ func layout(g *gocui.Gui) error {
 		v.TitleColor = gocui.ColorYellow
 		v.FrameColor = gocui.ColorRed
 		v.FrameRunes = []rune{'═', '║', '╔', '╗', '╚', '╝', '╠', '╣', '╦', '╩', '╬'}
+		v.PaddingX = 1
 		fmt.Fprintln(v, "View with fully customized frame and colored title differently.")
 		fmt.Fprintln(v, "It's connected to v3 with overlay LEFT.\n")
 		v.SetCursor(0, 3)

--- a/view.go
+++ b/view.go
@@ -105,6 +105,12 @@ type View struct {
 	//  []rune{'═','║','╔','╗','╚','╝','╠','╣','╦','╩','╬'}
 	FrameRunes []rune
 
+	// PaddingX specifies the horizontal padding (left and right) inside the frame.
+	PaddingX int
+
+	// PaddingY specifies the vertical padding (top and bottom) inside the frame.
+	PaddingY int
+
 	// If Wrap is true, the content that is written to this View is
 	// automatically wrapped when it is longer than its width. If true the
 	// view's x-origin will be ignored.
@@ -193,7 +199,7 @@ func (v *View) Dimensions() (int, int, int, int) {
 
 // Size returns the number of visible columns and rows in the View.
 func (v *View) Size() (x, y int) {
-	return v.x1 - v.x0 - 1, v.y1 - v.y0 - 1
+	return v.x1 - v.x0 - 1 - 2*v.PaddingX, v.y1 - v.y0 - 1 - 2*v.PaddingY
 }
 
 // Name returns the name of the view.
@@ -224,7 +230,7 @@ func (v *View) setRune(x, y int, ch rune, fgColor, bgColor Attribute) error {
 		ch = ' '
 	}
 
-	tcellSetCell(v.x0+x+1, v.y0+y+1, ch, fgColor, bgColor, v.outMode)
+	tcellSetCell(v.x0+x+1+v.PaddingX, v.y0+y+1+v.PaddingY, ch, fgColor, bgColor, v.outMode)
 
 	return nil
 }


### PR DESCRIPTION
Sometimes, it looks better to have a bit of padding on the edges of a view.

<img width="2034" height="896" alt="example of padding" src="https://github.com/user-attachments/assets/211b3884-7770-4db7-b15d-f4ea3238f43e" />

I added some padding to the `custom_frame.go` example to demonstrate this.