### PR TITLE
Support js/wasm build

### DIFF
--- a/gui_js.go
+++ b/gui_js.go
@@ -1,0 +1,15 @@
+// Copyright 2014 The gocui Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build js
+// +build js
+
+package gocui
+
+// getTermWindowSize is get terminal window size on js/wasm.
+// There is no tty ioctl available, so ask the tcell screen instead.
+func (g *Gui) getTermWindowSize() (int, int, error) {
+	x, y := screen.Size()
+	return x, y, nil
+}

--- a/gui_js.go
+++ b/gui_js.go
@@ -2,14 +2,72 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build js
-// +build js
+//go:build js && wasm
+// +build js,wasm
 
 package gocui
 
+import "syscall/js"
+
+// webSetSizeFunc is the js.Func registered as the global tcellSetSize.
+// It is kept so a subsequent NewGui can release the previous one.
+var webSetSizeFunc js.Func
+
 // getTermWindowSize is get terminal window size on js/wasm.
 // There is no tty ioctl available, so ask the tcell screen instead.
+//
+// If the hosting page defines a terminalCells() function returning
+// [cols, rows], the web terminal is resized to that size first, so the
+// terminal can fill the browser window instead of tcell's default 80x24.
+// The page can also call tcellSetSize(cols, rows) later (e.g. from a
+// window resize listener) to resize the running terminal; tcell posts an
+// EventResize and gocui relayouts as usual.
 func (g *Gui) getTermWindowSize() (int, int, error) {
+	applyWebTerminalCells()
+	if webSetSizeFunc.Truthy() {
+		webSetSizeFunc.Release()
+	}
+	webSetSizeFunc = js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		if len(args) == 2 &&
+			args[0].Type() == js.TypeNumber && args[1].Type() == js.TypeNumber {
+			setScreenSize(args[0].Int(), args[1].Int())
+		}
+		return nil
+	})
+	js.Global().Set("tcellSetSize", webSetSizeFunc)
 	x, y := screen.Size()
 	return x, y, nil
+}
+
+// applyWebTerminalCells asks the hosting page for the desired terminal size
+// via terminalCells() and applies it. The page is an untrusted boundary:
+// anything thrown or malformed (non-array, short array, non-numeric
+// elements) is ignored, keeping the current screen size.
+func applyWebTerminalCells() {
+	defer func() { _ = recover() }()
+	fn := js.Global().Get("terminalCells")
+	if fn.Type() != js.TypeFunction {
+		return
+	}
+	v := fn.Invoke()
+	if v.Type() != js.TypeObject || v.Length() < 2 {
+		return
+	}
+	w, h := v.Index(0), v.Index(1)
+	if w.Type() != js.TypeNumber || h.Type() != js.TypeNumber {
+		return
+	}
+	setScreenSize(w.Int(), h.Int())
+}
+
+// setScreenSize resizes the tcell screen if the tcell version in use
+// supports it (Screen.SetSize was added after the v2.4 pinned here, and
+// the WebAssembly backend implements it).
+func setScreenSize(w, h int) {
+	if w <= 0 || h <= 0 {
+		return
+	}
+	if s, ok := screen.(interface{ SetSize(int, int) }); ok {
+		s.SetSize(w, h)
+	}
 }

--- a/gui_others.go
+++ b/gui_others.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !windows
+//go:build !windows && !js
+// +build !windows,!js
 
 package gocui
 


### PR DESCRIPTION
## Summary

This PR makes gocui compile for `GOOS=js GOARCH=wasm`, so gocui applications can run in a browser using tcell's WebAssembly backend (`webfiles/`).

Currently a js/wasm build fails because `gui_others.go` relies on tty ioctls and signals that do not exist on js:

```
gui_others.go:35:34: undefined: syscall.SIGWINCH
gui_others.go:38:37: undefined: syscall.SYS_IOCTL
gui_others.go:39:30: undefined: syscall.TIOCGWINSZ
gui_others.go:49:16: undefined: syscall.SIGWINCH
```

## Changes

**Commit 1 — build support**
- Exclude `gui_others.go` from js builds (`//go:build !windows && !js`)
- Add `gui_js.go` with a `getTermWindowSize` implementation that asks the tcell screen for its size, which is how the WebAssembly backend reports the emulated terminal dimensions

**Commit 2 — let the hosting page control the terminal size (optional but makes browser apps practical)**
- If the page defines `terminalCells()` returning `[cols, rows]`, the terminal is sized to it at startup instead of tcell's default 80x24
- A global `tcellSetSize(cols, rows)` is registered so the page can resize the running terminal from a `resize` listener; tcell posts an `EventResize` and gocui relayouts as usual
- The page is treated as an untrusted boundary: thrown exceptions and malformed values are ignored. `Screen.SetSize` is looked up via an interface assertion because the tcell version pinned in go.mod (v2.4) predates it, so this PR requires no dependency bump; applications building with a newer tcell get the behavior automatically

## Testing

- `go build ./...` and `go test ./...` pass on darwin
- `GOOS=js GOARCH=wasm go build ./...` now succeeds
- Verified end to end with a real gocui application compiled to wasm and running in a browser via tcell's `webfiles`, including dynamic window resizing: https://koikoi.ngs.io (source: https://github.com/ngs/go-koikoi)