### PR TITLE
fix: Resume() to re-enable mouse after screen re-init

### DIFF
--- a/tcell_driver.go
+++ b/tcell_driver.go
@@ -29,7 +29,11 @@ func Suspend() {
 
 // Resume re-initializes the tcell screen, intended to be used after "Suspend" has been called
 func Resume() error {
-	return tcellInit()
+    if e := tcellInit(); e != nil {
+        return e
+    }
+    screen.EnableMouse()
+    return nil
 }
 
 // tcellInitSimulation creates a tcell simulated screen for testing


### PR DESCRIPTION
Resume() does not re-enable mouse after screen re-init

When `Suspend()` calls `screen.Fini()`, the `tcell` screen is torn down and mouse tracking is disabled. `Resume()` calls `tcellInit()` to create a fresh screen but never calls `screen.EnableMouse()`, while `MainLoop` only enables mouse once at startup. The result is that after any suspend/resume cycle, all mouse bindings (`MouseLeft`, `MouseRelease`, etc.) stop firing permanently.
 
This is particularly noticeable in terminal workflows where the TUI suspends to yield the terminal, then resumes. Here, the mouse works initially, then breaks after the first cycle.